### PR TITLE
Fixed number issue if user starts his number with +255 or  0

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,11 +64,20 @@ class _PaymentScreenState extends State<PaymentScreen> {
             ),
             ElevatedButton(
                 onPressed: () async {
+                      String userNumber = number.text;
+    if (userNumber[0] == "0") {
+      String checkedNumber = userNumber.replaceFirst("0", "255");
+      userNumber = checkedNumber;
+    }
+    if (userNumber[0] == "+") {
+      String checkedNumber = userNumber.substring(1);
+      userNumber = checkedNumber;
+    }
                   ChargeResponse? result = await shoket.charge(Payment(
                       amount: amount.text,
                       customerName: name.text,
                       email: email.text,
-                      numberUsed: number.text,
+                      numberUsed: userNumber,
                       channel: "halotel"));
 
                   if (result != null) {


### PR DESCRIPTION
As from Shoket documentation, user number should start with 255 and not +255 or 0. This PR fixes the issue in example app by checking if the number starts with 255 or 0.